### PR TITLE
Changed 302 to 301 for the actual redirection

### DIFF
--- a/src/Middleware/CheckForRedirect.php
+++ b/src/Middleware/CheckForRedirect.php
@@ -55,7 +55,7 @@ class CheckForRedirect {
             $redirect->increment('hits');
 
             // Redirect off to where we're going
-            return RedirectFacade::to($url);
+            return RedirectFacade::to($url, 301);
         }
 
         // By default, continue afterwards and bail out


### PR DESCRIPTION
Laravel defaults to 302 redirects, so we need to specify 301 in the Middleware.
